### PR TITLE
Update pulsenomore.c

### DIFF
--- a/pulsenomore.c
+++ b/pulsenomore.c
@@ -36,7 +36,7 @@
 #define LIBPULSE_SIMPLE		"libpulse-simple.so.0"
 
 #ifdef __NR_memfd_create
-static inline int memfd_create(const char *name, unsigned int flags) {
+inline int memfd_create(const char *name, unsigned int flags) {
 	return syscall(__NR_memfd_create, name, flags);
 }
 #else


### PR DESCRIPTION
Fails to compile as it was declared a static inline int on line 39 while it was declared an inline int earlier (see issue #1). Removing the static variable allows the program to compile without issue. 